### PR TITLE
Do not listen for mousedown when there is no menu opened

### DIFF
--- a/src/ContextMenu.elm
+++ b/src/ContextMenu.elm
@@ -117,7 +117,7 @@ shouldCloseOnClick closeOnDehover openState =
                 hover /= Container
 
         Nothing ->
-            True
+            False
 
 
 setHoverState : HoverState -> OpenState context -> OpenState context


### PR DESCRIPTION
Avoid having Close event triggered on every click of the application