### PR TITLE
add the ability for a left click

### DIFF
--- a/src/ContextMenu.elm
+++ b/src/ContextMenu.elm
@@ -2,7 +2,7 @@ module ContextMenu exposing
     ( ContextMenu, Msg, init, update, subscriptions
     , Item, item, itemWithAnnotation, disabled, icon, shortcut
     , Config, Direction(..), Overflow(..), Cursor(..), defaultConfig
-    , view, open, openIf
+    , view, open, openIf, openClick
     , setOnDehover
     )
 
@@ -35,7 +35,7 @@ The boilerplace functions. See [The Elm Architecture](https://guide.elm-lang.org
 
 # Advanced
 
-@docs setOnDehover
+@docs setOnDehover, openClick
 
 -}
 
@@ -590,6 +590,31 @@ openIf condition transform context =
     else
         on "contextmenu" (Decode.succeed (transform NoOp))
 
+{-| Similar to `open` but it opens on the left click instead of the right.
+
+This is useful if you want to improve accessibility and add a button that also
+responds to the left click.
+
+-}
+openClick : Bool -> (Msg context -> msg) -> context -> Attribute msg
+openClick condition transform context =
+    if condition then
+        Html.Events.custom
+            "click"
+            (position
+                |> Decode.map (RequestOpen context)
+                |> Decode.map transform
+                |> Decode.map
+                    (\msg ->
+                        { message = msg
+                        , stopPropagation = True
+                        , preventDefault = True
+                        }
+                    )
+            )
+
+    else
+        on "contextmenu" (Decode.succeed (transform NoOp))
 
 position : Decode.Decoder Position
 position =


### PR DESCRIPTION
I used your library for a work project and benefited greatly from it. However, I noticed during the user tests that hardly anyone actually made the right click. Most people assume that this does not work in a browser.

To improve accessibility, I have now added a small button to each element, which should open the menu on a left click. Unfortunately your library can't do this by itself, so please merged my request.
